### PR TITLE
fix(ci): bump uptime-monitor v1.41.0 -> v1.42.7 (unstick monitoring)

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -6,7 +6,7 @@
 # Your changes will be overwritten when the Upptime template updates (by default, weekly)
 # Instead, change .upptimerc.yml configuration and the workflows will be generated accordingly.
 #
-# 🔼 Upptime @v1.41.0
+# 🔼 Upptime @v1.42.7
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate graphs
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.7
         with:
           command: "graphs"
         env:

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -6,7 +6,7 @@
 # Your changes will be overwritten when the Upptime template updates (by default, weekly)
 # Instead, change .upptimerc.yml configuration and the workflows will be generated accordingly.
 #
-# 🔼 Upptime @v1.41.0
+# 🔼 Upptime @v1.42.7
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.7
         with:
           command: "response-time"
         env:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -6,7 +6,7 @@
 # Your changes will be overwritten when the Upptime template updates (by default, weekly)
 # Instead, change .upptimerc.yml configuration and the workflows will be generated accordingly.
 #
-# 🔼 Upptime @v1.41.0
+# 🔼 Upptime @v1.42.7
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -33,20 +33,20 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update template
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.7
         with:
           command: "update-template"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.7
         with:
           command: "response-time"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.7
         with:
           command: "readme"
         env:
@@ -57,7 +57,7 @@ jobs:
           workflow: Graphs CI
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.7
         with:
           command: "site"
         env:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -6,7 +6,7 @@
 # Your changes will be overwritten when the Upptime template updates (by default, weekly)
 # Instead, change .upptimerc.yml configuration and the workflows will be generated accordingly.
 #
-# 🔼 Upptime @v1.41.0
+# 🔼 Upptime @v1.42.7
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -33,7 +33,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.7
         with:
           command: "site"
         env:

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -6,7 +6,7 @@
 # Your changes will be overwritten when the Upptime template updates (by default, weekly)
 # Instead, change .upptimerc.yml configuration and the workflows will be generated accordingly.
 #
-# 🔼 Upptime @v1.41.0
+# 🔼 Upptime @v1.42.7
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.7
         with:
           command: "readme"
         env:

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -6,7 +6,7 @@
 # Your changes will be overwritten when the Upptime template updates (by default, weekly)
 # Instead, change .upptimerc.yml configuration and the workflows will be generated accordingly.
 #
-# 🔼 Upptime @v1.41.0
+# 🔼 Upptime @v1.42.7
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -6,7 +6,7 @@
 # Your changes will be overwritten when the Upptime template updates (by default, weekly)
 # Instead, change .upptimerc.yml configuration and the workflows will be generated accordingly.
 #
-# 🔼 Upptime @v1.41.0
+# 🔼 Upptime @v1.42.7
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -6,7 +6,7 @@
 # Your changes will be overwritten when the Upptime template updates (by default, weekly)
 # Instead, change .upptimerc.yml configuration and the workflows will be generated accordingly.
 #
-# 🔼 Upptime @v1.41.0
+# 🔼 Upptime @v1.42.7
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Check endpoint status
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.7
         with:
           command: "update"
         env:


### PR DESCRIPTION
Fixes the node_libcurl.node native-module crash in upptime/uptime-monitor@v1.41.0 on node20 runners that stalled Uptime CI and left stale 'Web App is down' (#4) / 'API is down' (#3) incidents open while both endpoints return 200. Bumps to latest v1.42.7 across all 8 generated workflows. After merge, the next Uptime CI run probes both endpoints and auto-closes the stale incidents.